### PR TITLE
Add GNOME 44 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "description": "Show battery estimated remaining time",
   "uuid": "batterytime@typeof.pw",
   "shell-version": [
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/pomoke/battery_time"
 }


### PR DESCRIPTION
This PR adds GNOME 44 support. This only adds `44` to `shell-version`, since no changes to the JavaScript are needed.

PS: You might be aware of some changes I made to the extension in November, adding battery percentage and time remaining, instead of only the remaining time. It would be nice to have a GUI so that one could choose whether they want one format or another. What do you think?