### PR TITLE
Fix warnings in port to Gnome 44

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -117,7 +117,7 @@ class Extension {
         let hours = remaining / 3600;
         let mins = remaining % 3600 / 60;
         PowerToggle.set({
-            label: remaining ? _('%d:%02d').format(hours,mins) : _('%d\u2009%%').format(this._proxy.Percentage),
+            title: remaining ? _('%d:%02d').format(hours,mins) : _('%d\u2009%%').format(this._proxy.Percentage),
             fallback_icon_name: this._proxy.IconName,
             gicon,
         });


### PR DESCRIPTION
Heya, running fedora silverblue 38 with Gnome 44 and noticed that the extension causes the following warnings from gnome-shell when activating it and when it updates the remaining time:

```bash
$ journalctl -f /usr/bin/gnome-shell
Mar 12 16:16:07 fedora gnome-shell[1332]: Trying to set label on QuickToggle. Use title instead.
```

This patch fixes that.