### PR TITLE
Port to gnome 45

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,5 @@ This extension serves as a replacement of battery remaining time,last seen in GN
 
 Remaining time is shown inline, so no additional menu item is created (currently).
 
-The extension works on GNOME 43 and 44 (needs more test). Of course, previous GNOME versions don't need this extension.
-
 ## License
 This program is distributed under the terms of the GNU General Public License, version 2 or later.

--- a/extension.js
+++ b/extension.js
@@ -24,9 +24,8 @@ import GObject from 'gi://GObject';
 import St from 'gi://St';
 import UPower from 'gi://UPowerGlib';
 
-import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 import { panel } from 'resource:///org/gnome/shell/ui/main.js';
-import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 import { loadInterfaceXML } from 'resource:///org/gnome/shell/misc/fileUtils.js';
 
 const System = panel.statusArea.quickSettings._system;
@@ -34,7 +33,6 @@ const PowerToggle = System._systemItem._powerToggle;
 
 const BUS_NAME = 'org.freedesktop.UPower';
 const OBJECT_PATH = '/org/freedesktop/UPower/devices/DisplayDevice';
-const GETTEXT_DOMAIN = "battery-time-gettext";
 
 const DisplayDeviceInterface = loadInterfaceXML('org.freedesktop.UPower.Device');
 const PowerManagerProxy = Gio.DBusProxy.makeProxyWrapper(DisplayDeviceInterface);
@@ -42,15 +40,10 @@ const PowerManagerProxy = Gio.DBusProxy.makeProxyWrapper(DisplayDeviceInterface)
 
 // See https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-42/js/ui/status/power.js.
 export default class BatteryTimeExtension extends Extension {
-    constructor(metadata) {
-	super(metadata);
-	this.initTranslations(GETTEXT_DOMAIN);
-    }
-
     enable() {
         //Stop original proxy
         PowerToggle._proxy = null;
-	//It's easier to use a new label than to unbind.
+        //It's easier to use a new label than to unbind.
         System._percentageLabel.destroy();
         System._percentageLabel = new St.Label({
             y_expand: true,
@@ -96,7 +89,7 @@ export default class BatteryTimeExtension extends Extension {
         PowerToggle.visible = this._proxy.IsPresent;
         if (!PowerToggle.visible) {
             return;
-	}
+        }
         // The icons
         let chargingState = this._proxy.State === UPower.DeviceState.CHARGING
             ? '-charging' : '';

--- a/extension.js
+++ b/extension.js
@@ -116,7 +116,7 @@ export default class BatteryTimeExtension extends Extension {
         let hours = remaining / 3600;
         let mins = remaining % 3600 / 60;
         PowerToggle.set({
-            label: remaining ? _('%d:%02d').format(hours,mins) : _('%d\u2009%%').format(this._proxy.Percentage),
+            title: remaining ? _('%d:%02d').format(hours,mins) : _('%d\u2009%%').format(this._proxy.Percentage),
             fallback_icon_name: this._proxy.IconName,
             gicon,
         });

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,0 @@
-gnome-extensions pack -o .. -f
-gnome-extensions install ../batterytime@typeof.pw.shell-extension.zip -f
-

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+gnome-extensions pack -o .. -f
+gnome-extensions install ../batterytime@typeof.pw.shell-extension.zip -f
+

--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,7 @@
   "description": "Show battery estimated remaining time",
   "uuid": "batterytime@typeof.pw",
   "shell-version": [
-    "43",
-    "44"
+    "45"
   ],
   "url": "https://github.com/pomoke/battery_time"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,7 @@
   "name": "Battery time",
   "description": "Show battery estimated remaining time",
   "uuid": "batterytime@typeof.pw",
+  "gettext-domain": "battery-time-gettext",
   "shell-version": [
     "45"
   ],


### PR DESCRIPTION
Hi, this PR should bring support for gnome 45. Tested on fedora silverblue 39.

This change is not backward compatible with gnome 43 and 44 because of the switch to Ecmascript Modules. I therefor removed 43 and 44 from the shell-version array in the manifest. If I understood it right, extensions.gnome.org supports different versions of the extension for different gnome-shell versions. I think it could be smart to branch off a 43-44 branch and have this patch be applied either to main or a new 45 branch. Let me know if you have questions!

 Also thanks for this extension, it was really nice working on this. :)

closes #8 