### PR TITLE
Changed percentageLabel to use time estimate, instead of percentage o…

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -106,7 +106,7 @@ export default class BatteryTimeExtension extends Extension {
         });
         const System = panel.statusArea.quickSettings._system;
         // Changed 9/6/24 this line below sets the text displayed on the DESKTOP top bar only
-        System._percentageLabel.set_text(remaining ? _('%d:%02d').format(hours,mins) : _('%d\u2009%%').format(this._proxy.Percentage))
+        System._percentageLabel.set_text(remaining ? _('%dh %02dm').format(hours,mins) : _('%d\u2009%%').format(this._proxy.Percentage))
     }
 
 }

--- a/extension.js
+++ b/extension.js
@@ -105,7 +105,8 @@ export default class BatteryTimeExtension extends Extension {
             gicon,
         });
         const System = panel.statusArea.quickSettings._system;
-        System._percentageLabel.set_text(_('%d\u2009%%').format(this._proxy.Percentage))
+        // Changed 9/6/24 this line below sets the text displayed on the DESKTOP top bar only
+        System._percentageLabel.set_text(remaining ? _('%d:%02d').format(hours,mins) : _('%d\u2009%%').format(this._proxy.Percentage))
     }
 
 }


### PR DESCRIPTION
I changed the formatting for the Desktop top bar label to show the formatting in "hh mm (ex. 0h 28m)". I'm currently on GNOME 46.0 and tested that this works as expected. I also added a comment to make it easier to find. 

This should close #3

Please let me know if I need to change or fix anything 