### PR TITLE
Update metadata.json to support GNOME 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/pomoke/battery_time"
 }


### PR DESCRIPTION
Extension seems to be working fine, with just just changing the metadata.json